### PR TITLE
add some missing "function" & "type" specifiers

### DIFF
--- a/grammars/wast.cson
+++ b/grammars/wast.cson
@@ -30,11 +30,11 @@
     'name': 'keyword.control.wast'
   }
   {
-    'match': '\\b(?i:i32|f32|i64|f64)\\b'
+    'match': '\\b(?i:i32|f32|i64|f64|anyfunc)\\b'
     'name': 'keyword.type.wast'
   }
   {
-    'match': '\\b(?i:assert_invalid|assert_trap|assert_return_nan|assert_return|module|invoke|memory|memory_size|grow_memory|table|export|import|global|type|result|param|local|segment|func|set_local|get_local|get_global|call_import|call_indirect|has_feature|label|block|block|const|failure|unreachable|tableswitch|start|select|nop)\\b'
+    'match': '\\b(?i:assert_invalid|assert_trap|assert_return_nan|assert_return|module|invoke|memory|memory_size|grow_memory|table|export|import|global|type|result|param|mut|local|segment|func|set_local|get_local|set_global|get_global|call_import|call_indirect|has_feature|label|block|end|const|failure|unreachable|tableswitch|start|select|nop)\\b'
     'name': 'support.function.wast'
   }
   {


### PR DESCRIPTION
Thanks for making this! :D

Also I was wondering, should we separate out some of these into some sort of modifier specifier? e.g. it is my understanding that `param` and `mut` are not functions. :P